### PR TITLE
Add ssl-cert package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     state: 'latest'
     install_recommends: False
   register: mysql_install_status
-  with_items: [ 'python-mysqldb', 'mysql-server', 'automysqlbackup' ]
+  with_items: [ 'python-mysqldb', 'mysql-server', 'automysqlbackup', 'ssl-cert' ]
 
 - name: Add MySQL system user to specified groups
   user:


### PR DESCRIPTION
In the task "Add MySQL system user to specified groups" if you left the default configuration, you need the ssl-cert group.

This group is append when you install ssl-cert. So I add this package in the task "Install MySQL-related packages".